### PR TITLE
noetic_devel branch

### DIFF
--- a/rviz_plugin_selected_points_topic/CMakeLists.txt
+++ b/rviz_plugin_selected_points_topic/CMakeLists.txt
@@ -2,88 +2,132 @@
 ## This CMakeLists.txt file for rviz_plugin_tutorials builds both the TeleopPanel tutorial and the ImuDisplay tutorial.
 ##
 ## First start with some standard catkin stuff.
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 2.8.3)
 project(rviz_plugin_selected_points_topic)
 find_package(catkin REQUIRED COMPONENTS rviz)
 catkin_package()
 include_directories(${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
+string(REPLACE "/" ";" ROS_VER_RAW ${CMAKE_PREFIX_PATH_AS_IS})
+list(GET ${ROS_VER_RAW} -1 ROS_VER)
 
-function(dump_cmake_variables)
-    get_cmake_property(_variableNames VARIABLES)
-    list (SORT _variableNames)
-    foreach (_variableName ${_variableNames})
-        if (ARGV0)
-            unset(MATCHED)
-            string(REGEX MATCH ${ARGV0} MATCHED ${_variableName})
-            if (NOT MATCHED)
-                continue()
-            endif()
-        endif()
-        message(STATUS "${_variableName}=${${_variableName}}")
-    endforeach()
-endfunction()
+if(${ROS_VER} MATCHES "noetic")
 
-## This plugin includes Qt widgets, so we must include Qt like so:
-# find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
-find_package(Qt5 COMPONENTS Core Gui UiTools Widgets REQUIRED)
-# include(${QT_USE_FILE})
-include_directories(
-  ${Qt5Core_INCLUDE_DIRS}
-  ${Qt5Gui_INCLUDE_DIRS}
-  ${Qt5UiTools_INCLUDE_DIRS}
-  ${Qt5Widgets_INCLUDE_DIRS}
-)
+  ## This plugin includes Qt widgets, so we must include Qt like so:
+  # find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
+  find_package(Qt5 COMPONENTS Core Gui UiTools Widgets REQUIRED)
+  # include(${QT_USE_FILE})
+  include_directories(
+    ${Qt5Core_INCLUDE_DIRS}
+    ${Qt5Gui_INCLUDE_DIRS}
+    ${Qt5UiTools_INCLUDE_DIRS}
+    ${Qt5Widgets_INCLUDE_DIRS}
+  )
 
-## I prefer the Qt signals and slots to avoid defining "emit", "slots",
-## etc because they can conflict with boost signals, so define QT_NO_KEYWORDS here.
-add_definitions(-DQT_NO_KEYWORDS)
+  ## I prefer the Qt signals and slots to avoid defining "emit", "slots",
+  ## etc because they can conflict with boost signals, so define QT_NO_KEYWORDS here.
+  add_definitions(-DQT_NO_KEYWORDS)
 
-## Here we specify which header files need to be run through "moc",
-## Qt's meta-object compiler.
-qt5_wrap_cpp(MOC_FILES
-  src/selected_points_topic.h
-)
+  ## Here we specify which header files need to be run through "moc",
+  ## Qt's meta-object compiler.
+  qt5_wrap_cpp(MOC_FILES
+    src/selected_points_topic.h
+  )
 
-## Here we specify the list of source files, including the output of
-## the previous command which is stored in ``${MOC_FILES}``.
-set(SOURCE_FILES
-  src/selected_points_topic.cpp
-  ${MOC_FILES}
-)
-dump_cmake_variables()
+  ## Here we specify the list of source files, including the output of
+  ## the previous command which is stored in ``${MOC_FILES}``.
+  set(SOURCE_FILES
+    src/selected_points_topic.cpp
+    ${MOC_FILES}
+  )
 
-## An rviz plugin is just a shared library, so here we declare the
-## library to be called ``${PROJECT_NAME}`` (which is
-## "rviz_plugin_tutorials", or whatever your version of this project
-## is called) and specify the list of source files we collected above
-## in ``${SOURCE_FILES}``.
-add_library(${PROJECT_NAME} ${SOURCE_FILES})
+  ## An rviz plugin is just a shared library, so here we declare the
+  ## library to be called ``${PROJECT_NAME}`` (which is
+  ## "rviz_plugin_tutorials", or whatever your version of this project
+  ## is called) and specify the list of source files we collected above
+  ## in ``${SOURCE_FILES}``.
+  add_library(${PROJECT_NAME} ${SOURCE_FILES})
 
-## Link the library with whatever Qt libraries have been defined by
-## the ``find_package(Qt4 ...)`` line above, and with whatever libraries
-## catkin has included.
-##
-## Although this puts "rviz_plugin_tutorials" (or whatever you have
-## called the project) as the name of the library, cmake knows it is a
-## library and names the actual file something like
-## "librviz_plugin_tutorials.so", or whatever is appropriate for your
-## particular OS.
-target_link_libraries(${PROJECT_NAME} ${Qt5_Core_LIBRARIES} ${Qt5_Gui_LIBRARIES} ${Qt5_UiTools_LIBRARIES} ${Qt5_Widgets_LIBRARIES} ${catkin_LIBRARIES} ${ROS_LIBRARIES})
-## END_TUTORIAL
+  ## Link the library with whatever Qt libraries have been defined by
+  ## the ``find_package(Qt4 ...)`` line above, and with whatever libraries
+  ## catkin has included.
+  ##
+  ## Although this puts "rviz_plugin_tutorials" (or whatever you have
+  ## called the project) as the name of the library, cmake knows it is a
+  ## library and names the actual file something like
+  ## "librviz_plugin_tutorials.so", or whatever is appropriate for your
+  ## particular OS.
+  target_link_libraries(${PROJECT_NAME} ${Qt5_Core_LIBRARIES} ${Qt5_Gui_LIBRARIES} ${Qt5_UiTools_LIBRARIES} ${Qt5_Widgets_LIBRARIES} ${catkin_LIBRARIES} ${ROS_LIBRARIES})
+  ## END_TUTORIAL
 
 
-## Install rules
+  ## Install rules
 
-install(TARGETS
-  ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
+  install(TARGETS
+    ${PROJECT_NAME}
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  )
 
-install(FILES 
-  plugin_description.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+  install(FILES 
+    plugin_description.xml
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
+elseif(${ROS_VER} MATCHES "melodic")
+  ## This plugin includes Qt widgets, so we must include Qt like so:
+  find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
+  include(${QT_USE_FILE})
+
+  ## I prefer the Qt signals and slots to avoid defining "emit", "slots",
+  ## etc because they can conflict with boost signals, so define QT_NO_KEYWORDS here.
+  add_definitions(-DQT_NO_KEYWORDS)
+
+  ## Here we specify which header files need to be run through "moc",
+  ## Qt's meta-object compiler.
+  qt4_wrap_cpp(MOC_FILES
+    src/selected_points_topic.h
+  )
+
+  ## Here we specify the list of source files, including the output of
+  ## the previous command which is stored in ``${MOC_FILES}``.
+  set(SOURCE_FILES
+    src/selected_points_topic.cpp
+    ${MOC_FILES}
+  )
+
+  ## An rviz plugin is just a shared library, so here we declare the
+  ## library to be called ``${PROJECT_NAME}`` (which is
+  ## "rviz_plugin_tutorials", or whatever your version of this project
+  ## is called) and specify the list of source files we collected above
+  ## in ``${SOURCE_FILES}``.
+  add_library(${PROJECT_NAME} ${SOURCE_FILES})
+
+  ## Link the library with whatever Qt libraries have been defined by
+  ## the ``find_package(Qt4 ...)`` line above, and with whatever libraries
+  ## catkin has included.
+  ##
+  ## Although this puts "rviz_plugin_tutorials" (or whatever you have
+  ## called the project) as the name of the library, cmake knows it is a
+  ## library and names the actual file something like
+  ## "librviz_plugin_tutorials.so", or whatever is appropriate for your
+  ## particular OS.
+  target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${catkin_LIBRARIES})
+  ## END_TUTORIAL
+
+
+  ## Install rules
+
+  install(TARGETS
+    ${PROJECT_NAME}
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  )
+
+  install(FILES 
+    plugin_description.xml
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+endif()

--- a/rviz_plugin_selected_points_topic/CMakeLists.txt
+++ b/rviz_plugin_selected_points_topic/CMakeLists.txt
@@ -2,17 +2,39 @@
 ## This CMakeLists.txt file for rviz_plugin_tutorials builds both the TeleopPanel tutorial and the ImuDisplay tutorial.
 ##
 ## First start with some standard catkin stuff.
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(rviz_plugin_selected_points_topic)
 find_package(catkin REQUIRED COMPONENTS rviz)
 catkin_package()
 include_directories(${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
+
+function(dump_cmake_variables)
+    get_cmake_property(_variableNames VARIABLES)
+    list (SORT _variableNames)
+    foreach (_variableName ${_variableNames})
+        if (ARGV0)
+            unset(MATCHED)
+            string(REGEX MATCH ${ARGV0} MATCHED ${_variableName})
+            if (NOT MATCHED)
+                continue()
+            endif()
+        endif()
+        message(STATUS "${_variableName}=${${_variableName}}")
+    endforeach()
+endfunction()
+
 ## This plugin includes Qt widgets, so we must include Qt like so:
 # find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
 find_package(Qt5 COMPONENTS Core Gui UiTools Widgets REQUIRED)
 # include(${QT_USE_FILE})
+include_directories(
+  ${Qt5Core_INCLUDE_DIRS}
+  ${Qt5Gui_INCLUDE_DIRS}
+  ${Qt5UiTools_INCLUDE_DIRS}
+  ${Qt5Widgets_INCLUDE_DIRS}
+)
 
 ## I prefer the Qt signals and slots to avoid defining "emit", "slots",
 ## etc because they can conflict with boost signals, so define QT_NO_KEYWORDS here.
@@ -30,6 +52,7 @@ set(SOURCE_FILES
   src/selected_points_topic.cpp
   ${MOC_FILES}
 )
+dump_cmake_variables()
 
 ## An rviz plugin is just a shared library, so here we declare the
 ## library to be called ``${PROJECT_NAME}`` (which is
@@ -47,7 +70,7 @@ add_library(${PROJECT_NAME} ${SOURCE_FILES})
 ## library and names the actual file something like
 ## "librviz_plugin_tutorials.so", or whatever is appropriate for your
 ## particular OS.
-target_link_libraries(${PROJECT_NAME} ${Qt5_Core_LIBRARIES} ${Qt5_Gui_LIBRARIES} ${Qt5_UiTools_LIBRARIES} ${Qt5_Widgets_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${Qt5_Core_LIBRARIES} ${Qt5_Gui_LIBRARIES} ${Qt5_UiTools_LIBRARIES} ${Qt5_Widgets_LIBRARIES} ${catkin_LIBRARIES} ${ROS_LIBRARIES})
 ## END_TUTORIAL
 
 
@@ -63,5 +86,4 @@ install(TARGETS
 install(FILES 
   plugin_description.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-
 

--- a/rviz_plugin_selected_points_topic/CMakeLists.txt
+++ b/rviz_plugin_selected_points_topic/CMakeLists.txt
@@ -10,8 +10,9 @@ include_directories(${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
 ## This plugin includes Qt widgets, so we must include Qt like so:
-find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
-include(${QT_USE_FILE})
+# find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
+find_package(Qt5 COMPONENTS Core Gui UiTools Widgets REQUIRED)
+# include(${QT_USE_FILE})
 
 ## I prefer the Qt signals and slots to avoid defining "emit", "slots",
 ## etc because they can conflict with boost signals, so define QT_NO_KEYWORDS here.
@@ -19,7 +20,7 @@ add_definitions(-DQT_NO_KEYWORDS)
 
 ## Here we specify which header files need to be run through "moc",
 ## Qt's meta-object compiler.
-qt4_wrap_cpp(MOC_FILES
+qt5_wrap_cpp(MOC_FILES
   src/selected_points_topic.h
 )
 
@@ -46,7 +47,7 @@ add_library(${PROJECT_NAME} ${SOURCE_FILES})
 ## library and names the actual file something like
 ## "librviz_plugin_tutorials.so", or whatever is appropriate for your
 ## particular OS.
-target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${Qt5_Core_LIBRARIES} ${Qt5_Gui_LIBRARIES} ${Qt5_UiTools_LIBRARIES} ${Qt5_Widgets_LIBRARIES} ${catkin_LIBRARIES})
 ## END_TUTORIAL
 
 

--- a/rviz_plugin_selected_points_topic/CMakeLists.txt
+++ b/rviz_plugin_selected_points_topic/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories(${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
 string(REPLACE "/" ";" ROS_VER_RAW ${CMAKE_PREFIX_PATH_AS_IS})
-list(GET ${ROS_VER_RAW} -1 ROS_VER)
+list(GET ROS_VER_RAW -1 ROS_VER)
 
 if(${ROS_VER} MATCHES "noetic")
 

--- a/rviz_plugin_selected_points_topic/package.xml
+++ b/rviz_plugin_selected_points_topic/package.xml
@@ -12,8 +12,10 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>rviz</build_depend>
+  <build_depend>qt_gui</build_depend>
 
   <run_depend>rviz</run_depend>
+  <run_depend>qt_gui</run_depend>
 
   <export>
       <rosdoc config="${prefix}/rosdoc.yaml"/>

--- a/sticky_fingers/src/sticky_fingers.cpp
+++ b/sticky_fingers/src/sticky_fingers.cpp
@@ -1,3 +1,5 @@
+#include <gazebo/gazebo_config.h>
+
 #include <gazebo/sensors/sensors.hh>
 #include <gazebo_ros_control/gazebo_ros_control_plugin.h>
 #include <ros/ros.h>
@@ -5,9 +7,11 @@
 
 #include <std_srvs/SetBool.h>
 
-#include <gazebo/gazebo_config.h>
-
-#define NEW_GAZEBO_INTERFACE (GAZEBO_MAJOR_VERSION >= 10)
+#if (GAZEBO_MAJOR_VERSION > 10)
+#define NEW_GAZEBO_INTERFACE 0
+#else
+#define NEW_GAZEBO_INTERFACE 1
+#endif
 
 #define OLD_GAZEBO_UPDATE ((GAZEBO_MAJOR_VERSION == 9) || (GAZEBO_MINOR_VERSION >= 19))
 

--- a/sticky_fingers/src/sticky_fingers.cpp
+++ b/sticky_fingers/src/sticky_fingers.cpp
@@ -7,13 +7,17 @@
 
 #include <std_srvs/SetBool.h>
 
-#if (GAZEBO_MAJOR_VERSION > 10)
-#define NEW_GAZEBO_INTERFACE 0
+#if ((GAZEBO_MAJOR_VERSION > 10) || ((GAZEBO_MAJOR_VERSION == 9) && (GAZEBO_MINOR_VERSION >=19)))
+#define OLD_GAZEBO_INTERFACE 0
 #else
-#define NEW_GAZEBO_INTERFACE 1
+#define OLD_GAZEBO_INTERFACE 1
 #endif
 
-#define OLD_GAZEBO_UPDATE ((GAZEBO_MAJOR_VERSION == 9) || (GAZEBO_MINOR_VERSION >= 19))
+#if ((GAZEBO_MAJOR_VERSION == 9) && (GAZEBO_MINOR_VERSION >= 19))
+#define OLD_GAZEBO_UPDATE 1
+#else
+#define OLD_GAZEBO_UPDATE 0
+#endif
 
 #if OLD_GAZEBO_UPDATE
 #include "ignition/math.hh"
@@ -55,7 +59,7 @@ namespace gazebo{
 						if(strcmp(msg->contact(i).collision1().c_str(), this->finger_name.c_str())){
 							candidate =
 								boost::dynamic_pointer_cast<physics::Collision>(
-#if NEW_GAZEBO_INTERFACE
+#if OLD_GAZEBO_INTERFACE
 									this->finger_world->GetEntity(msg->contact(i).collision1())
 #else
 									this->finger_world->EntityByName(msg->contact(i).collision1())
@@ -67,7 +71,7 @@ namespace gazebo{
 						if(strcmp(msg->contact(i).collision2().c_str(), this->finger_name.c_str())){
 							candidate =
 								boost::dynamic_pointer_cast<physics::Collision>(
-#if NEW_GAZEBO_INTERFACE
+#if OLD_GAZEBO_INTERFACE
 									this->finger_world->GetEntity(msg->contact(i).collision1())
 #else
 									this->finger_world->EntityByName(msg->contact(i).collision1())
@@ -77,7 +81,7 @@ namespace gazebo{
 						}
 						if(candidate != NULL){
 							if(!candidate->IsStatic()){
-#if NEW_GAZEBO_INTERFACE
+#if OLD_GAZEBO_INTERFACE
 								if(candidate->GetInertial()->GetMass() <= this->max_mass){//Ignore heavy objects
 #else
 								if(candidate->GetInertial()->Mass() <= this->max_mass){//Ignore heavy objects
@@ -90,14 +94,14 @@ namespace gazebo{
 									this->held_object->SetCollideMode("ghost");
 									
 									//Attach the joint
-#if NEW_GAZEBO_INTERFACE
+#if OLD_GAZEBO_INTERFACE
 									this->fixedJoint->Load(this->finger_link, held_object, math::Pose());
 #else
 									this->fixedJoint->Load(this->finger_link, held_object, ignition::math::Pose3d());
 #endif
 									//The joint limits have to be set after attachment:
 									// http://answers.gazebosim.org/question/2824/error-when-setting-dynamically-created-joints-axis-in-gazebo-180/
-#if NEW_GAZEBO_INTERFACE
+#if OLD_GAZEBO_INTERFACE
 									this->fixedJoint->SetAxis(0, gazebo::math::Vector3(0.0, 0.0, 1.0));
 									this->fixedJoint->SetLowStop(0, gazebo::math::Angle(0.0));
 									this->fixedJoint->SetHighStop(0, gazebo::math::Angle(0.0));
@@ -160,7 +164,7 @@ namespace gazebo{
 				this->finger_model = mod;
 				this->finger_world = finger_model->GetWorld();
 				this->finger_link = boost::dynamic_pointer_cast<physics::Link>(
-#if NEW_GAZEBO_INTERFACE
+#if OLD_GAZEBO_INTERFACE
 					this->finger_world->GetEntity(this->finger_name)
 #else
 					this->finger_world->EntityByName(this->finger_name)
@@ -169,7 +173,7 @@ namespace gazebo{
 				
 				//Initialize the joint.
 				//We use a prismatic joint that will have limits of (0,0) because fixed joints are not natively supported in this version of Gazebo
-#if NEW_GAZEBO_INTERFACE
+#if OLD_GAZEBO_INTERFACE
 				this->fixedJoint = this->finger_world->GetPhysicsEngine()->CreateJoint("prismatic", this->finger_model);
 #else
 				this->fixedJoint = this->finger_world->Physics()->CreateJoint("prismatic", this->finger_model);
@@ -189,14 +193,14 @@ namespace gazebo{
 				
 				//Create a listener on those contacts
 				this->contact_node = transport::NodePtr(new transport::Node());
-#if NEW_GAZEBO_INTERFACE				
+#if OLD_GAZEBO_INTERFACE				
 				this->contact_node->Init(this->finger_world->GetName());
 #else
 				this->contact_node->Init(this->finger_world->Name());
 #endif
 				if (!collisions.empty()){
 					// Create a filter to receive collision information
-#if NEW_GAZEBO_INTERFACE
+#if OLD_GAZEBO_INTERFACE
 					physics::ContactManager * mgr = this->finger_world->GetPhysicsEngine()->GetContactManager();
 #else
 					physics::ContactManager * mgr = this->finger_world->Physics()->GetContactManager();

--- a/sticky_fingers/src/sticky_fingers.cpp
+++ b/sticky_fingers/src/sticky_fingers.cpp
@@ -1,3 +1,4 @@
+#include <gazebo/gazebo_config.h>
 #include <gazebo/sensors/sensors.hh>
 #include <gazebo_ros_control/gazebo_ros_control_plugin.h>
 #include <ros/ros.h>
@@ -41,7 +42,11 @@ namespace gazebo{
 						if(strcmp(msg->contact(i).collision1().c_str(), this->finger_name.c_str())){
 							candidate =
 								boost::dynamic_pointer_cast<physics::Collision>(
+#if GAZEBO_MAJOR_VERSION < 11
 									this->finger_world->GetEntity(msg->contact(i).collision1())
+#else
+									this->finger_world->EntityByName(msg->contact(i).collision1())
+#endif
 								)
 							->GetLink();
 
@@ -49,13 +54,21 @@ namespace gazebo{
 						if(strcmp(msg->contact(i).collision2().c_str(), this->finger_name.c_str())){
 							candidate =
 								boost::dynamic_pointer_cast<physics::Collision>(
+#if GAZEBO_MAJOR_VERSION < 11
 									this->finger_world->GetEntity(msg->contact(i).collision1())
+#else
+									this->finger_world->EntityByName(msg->contact(i).collision1())
+#endif
 								)
 							->GetLink();
 						}
 						if(candidate != NULL){
 							if(!candidate->IsStatic()){
+#if GAZEBO_MAJOR_VERSION < 11
 								if(candidate->GetInertial()->GetMass() <= this->max_mass){//Ignore heavy objects
+#else
+								if(candidate->GetInertial()->Mass() <= this->max_mass){//Ignore heavy objects
+#endif
 									ROS_INFO("Finger grabbing link %s.", candidate->GetName().c_str());
 
 									this->held_object = candidate;
@@ -64,12 +77,22 @@ namespace gazebo{
 									this->held_object->SetCollideMode("ghost");
 									
 									//Attach the joint
+#if GAZEBO_MAJOR_VERSION < 11
 									this->fixedJoint->Load(this->finger_link, held_object, math::Pose());
+#else
+									this->fixedJoint->Load(this->finger_link, held_object, ignition::math::Pose3d());
+#endif
 									//The joint limits have to be set after attachment:
 									// http://answers.gazebosim.org/question/2824/error-when-setting-dynamically-created-joints-axis-in-gazebo-180/
+#if GAZEBO_MAJOR_VERSION < 11
 									this->fixedJoint->SetAxis(0, gazebo::math::Vector3(0.0, 0.0, 1.0));
 									this->fixedJoint->SetLowStop(0, gazebo::math::Angle(0.0));
 									this->fixedJoint->SetHighStop(0, gazebo::math::Angle(0.0));
+#else
+									this->fixedJoint->SetAxis(0, ignition::math::Vector3(0.0, 0.0, 1.0));
+									this->fixedJoint->SetParam("lo_stop", 0, ignition::math::Angle(0.0));
+									this->fixedJoint->SetParam("hi_stop", 0, ignition::math::Angle(0.0));
+#endif
 									this->fixedJoint->Init();
 
 									break;
@@ -120,12 +143,20 @@ namespace gazebo{
 				this->finger_model = mod;
 				this->finger_world = finger_model->GetWorld();
 				this->finger_link = boost::dynamic_pointer_cast<physics::Link>(
+#if GAZEBO_MAJOR_VERSION < 11
 					this->finger_world->GetEntity(this->finger_name)
+#else
+					this->finger_world->EntityByName(this->finger_name)
+#endif
 				);
 				
 				//Initialize the joint.
 				//We use a prismatic joint that will have limits of (0,0) because fixed joints are not natively supported in this version of Gazebo
+#if GAZEBO_MAJOR_VERSION < 11
 				this->fixedJoint = this->finger_world->GetPhysicsEngine()->CreateJoint("prismatic", this->finger_model);
+#else
+				this->fixedJoint = this->finger_world->Physics()->CreateJoint("prismatic", this->finger_model);
+#endif
 				this->fixedJoint->SetName(this->finger_model->GetName() + "__sticking_joint__");
 				
 				//Pull out all possible collision objects from the link
@@ -141,10 +172,18 @@ namespace gazebo{
 				
 				//Create a listener on those contacts
 				this->contact_node = transport::NodePtr(new transport::Node());
+#if GAZEBO_MAJOR_VERSION < 11				
 				this->contact_node->Init(this->finger_world->GetName());
+#else
+				this->contact_node->Init(this->finger_world->Name());
+#endif
 				if (!collisions.empty()){
 					// Create a filter to receive collision information
+#if GAZEBO_MAJOR_VERSION < 11
 					physics::ContactManager * mgr = this->finger_world->GetPhysicsEngine()->GetContactManager();
+#else
+					physics::ContactManager * mgr = this->finger_world->Physics()->GetContactManager();
+#endif
 					std::string topic = mgr->CreateFilter(finger_name, collisions);
 					if (!this->contact_sub){
 						this->contact_sub = this->contact_node->Subscribe(topic, &StickyFingers::ContactCB, this);


### PR DESCRIPTION
This gets everything to compile under ROS Noetic.  The rviz_plugin_selected_points_topic package has been converted to use Qt5, but it includes file from ROS that appears to not be converted Qt5 and this package fails.  That package is turned off by placing a CATKIN_IGNORE file in the base directory. 

There newest update for Melodic breaks sticky_fingers as well.  It uses Gazebo 9.19, but requires the same updates that Noetic requires for Gazebo 11, but there is on hitch.  That has been added in a way that should allow Melodic using an earlier Gazebo to continue to work and that Noetic still works.

These updates are not required for mobot functionality in Noetic (or Melodic).